### PR TITLE
Fix URL percent escaping to use UTF-8 encoding

### DIFF
--- a/ifmap.py
+++ b/ifmap.py
@@ -545,10 +545,6 @@ urlable_pattern = re.compile('[+-;@-z]+')
 
 def escape_url_string(val):
     """Apply URL escaping (percent escapes) to a string.
-    This is a bit over-zealous; it matches the behavior of the original
-    C ifmap.
-    Does not work correctly on Unicode characters outside the Latin-1
-    range (0 to 0xFF).
     """
     res = []
     pos = 0
@@ -559,7 +555,8 @@ def escape_url_string(val):
             pos = match.end()
         else:
             ch = val[pos]
-            res.append('%%%02X' % (ord(ch) & 0xFF),)
+            for chenc in ch.encode('utf8'):
+              res.append('%%%02X' % (chenc,))
             pos += 1
     return ''.join(res)
 


### PR DESCRIPTION
In the depths of the "competition2018" directory, we already have a file with a non-ASCII character in it: https://ifarchive.org/indexes/if-archive/games/competition2018/The%20master%20of%20the%20land/img/ contains the file "menú principal.jpg".

The logic in ifmap to escape the HTML does the right thing, but not the logic to escape the URL. As I understand it, percent escapes in URLs should be treated as being UTF-8 encoded. This patch generates what looks like the right URL for this file, and works on Windows. When I take the generated URL and use it on www.ifarchive.org, it works there, too.